### PR TITLE
fix: handle thin squads and Windows watch/hermes crashes gracefully

### DIFF
--- a/fantasybot/agent.py
+++ b/fantasybot/agent.py
@@ -125,17 +125,24 @@ def review(client, days_to_matchday=None):
     events = state.diff_snapshots(prev, curr)
     state.save_snapshot(curr)
 
-    # 2) lineup
-    best = lineup_opt.optimize(team, prob_index)
-    best_ids = lineup_opt.payload_ids(best)
-    lineup_changed = best_ids != _current_xi_ids(client, tid)
+    # 2) lineup (squad may be temporarily too thin for any valid formation,
+    # e.g. early season / after sales — degrade gracefully instead of crashing)
+    try:
+        best = lineup_opt.optimize(team, prob_index)
+        best_ids = lineup_opt.payload_ids(best)
+        lineup_changed = best_ids != _current_xi_ids(client, tid)
+        lineup_error = None
+    except ValueError as e:
+        best = None
+        lineup_changed = False
+        lineup_error = str(e)
 
     # 3) flips, needs and sales
     flips = [o for o in flip.opportunities(client, lid)
              if o["margin_pct"] > 0 and o["buy_price"] <= team["teamMoney"]][:5]
     gaps = needs_mod.gaps(team)
     needs_report = needs_mod.advise(client, lid, team, days_to_matchday)
-    sells = sell_mod.sell_candidates(team, best, trends_index())
+    sells = sell_mod.sell_candidates(team, best, trends_index()) if best else []
 
     # 4) buyout targets + reminders
     targets = clause_targets(market, team, prob_index)
@@ -178,8 +185,9 @@ def review(client, days_to_matchday=None):
         "events": events,
         "money": team["teamMoney"],
         "matchday": {"kickoff": kickoff, "days": days_to_matchday},
-        "lineup": {"formation": best["formation"], "changed": lineup_changed,
-                   "total": best["total"], "watch": best.get("watch", [])},
+        "lineup": ({"formation": best["formation"], "changed": lineup_changed,
+                    "total": best["total"], "watch": best.get("watch", [])}
+                   if best else {"error": lineup_error}),
         "flips": flips,
         "gaps": gaps,
         "needs": needs_report,

--- a/fantasybot/cli.py
+++ b/fantasybot/cli.py
@@ -187,7 +187,9 @@ def cmd_agent(args):
     events.emit("review", f"Review: {cambios}",
                 detail={"balance": f"{rep['money']:,}",
                         "flips": len(rep.get("flips", [])),
-                        "lineup": "change" if rep["lineup"]["changed"] else "already optimal"})
+                        "lineup": ("change" if rep["lineup"].get("changed")
+                                    else ("error" if rep["lineup"].get("error")
+                                          else "already optimal"))})
 
     if args.json:
         return _print_json(rep)
@@ -217,12 +219,15 @@ def cmd_agent(args):
         print(f"Next matchday: {md['kickoff']}"
               + (f"  ({dias:.1f} days left)" if dias is not None else ""))
     lu = rep["lineup"]
-    d, m, f = lu["formation"]
-    tag = "  (WORTH CHANGING)" if lu["changed"] else "  (already the best)"
-    print(f"Optimal lineup: {d}-{m}-{f}{tag}")
-    for w in lu.get("watch", []):
-        print(f"  ⚠ {w['nombre']} ({w['valor']:,}) outside the likely XI "
-              f"— transfer/injury? watch (sell?)")
+    if lu.get("error"):
+        print(f"\nOptimal lineup: NOT AVAILABLE ({lu['error']})")
+    else:
+        d, m, f = lu["formation"]
+        tag = "  (WORTH CHANGING)" if lu["changed"] else "  (already the best)"
+        print(f"Optimal lineup: {d}-{m}-{f}{tag}")
+        for w in lu.get("watch", []):
+            print(f"  ⚠ {w['nombre']} ({w['valor']:,}) outside the likely XI "
+                  f"— transfer/injury? watch (sell?)")
 
     if rep["flips"]:
         print("\nFlip opportunities (buy to resell):")
@@ -356,7 +361,6 @@ def cmd_watch(args):
     - `--hermes`   triggers the Hermes brain with the skill (LLM), if installed.
     Without flags, it just monitors: you'll see the next cron cycle live.
     """
-    import subprocess
     import threading
     import webbrowser
     from . import monitor
@@ -369,11 +373,10 @@ def cmd_watch(args):
 
     def fire():
         time.sleep(1.2)  # let the UI connect the stream before starting
-        if args.hermes:
-            subprocess.run(["hermes", "-z", monitor.HERMES_PROMPT,
-                            "--skill", "fantasy-manager"])
-        elif args.run:
-            subprocess.run([sys.executable, "-m", "fantasybot", "agent", "--execute"])
+        # Goes through monitor.trigger() so this can't race a concurrent
+        # "Launch agent" button click (or a second watch process) into
+        # firing two real agent cycles at once.
+        monitor.trigger("hermes" if args.hermes else "agent")
 
     if args.run or args.hermes:
         threading.Thread(target=fire, daemon=True).start()

--- a/fantasybot/monitor.py
+++ b/fantasybot/monitor.py
@@ -47,9 +47,15 @@ def _insights():
     if not shutil.which("hermes"):
         return {"available": False}
     try:
+        # `hermes insights` may print non-ASCII (emoji, box-drawing) that the
+        # console's default codepage (e.g. cp1252 on Windows) can't decode;
+        # force UTF-8 and never let a stray byte blow up the reader thread.
         out = subprocess.run(["hermes", "insights", "--days", "1"],
-                             capture_output=True, text=True, timeout=20).stdout
+                             capture_output=True, text=True, timeout=20,
+                             encoding="utf-8", errors="replace").stdout
     except (OSError, subprocess.SubprocessError):
+        return {"available": False}
+    if not out:
         return {"available": False}
 
     def grab(label):
@@ -63,6 +69,32 @@ def _insights():
             "total_tokens": grab("Total tokens"),
             "output_tokens": grab("Output tokens"),
             "active_time": tm.group(1) if tm else None}
+
+
+def trigger(mode):
+    """Runs one agent cycle in a background thread, guarded by `_RUNNING` so a
+    concurrent trigger (CLI --run/--hermes racing the UI's own button, or two
+    `watch` processes pointed at the same team) can't fire a second real cycle
+    on top of one already in flight. Returns False if one was already running.
+    """
+    global _RUNNING
+    if _RUNNING:
+        return False
+
+    def go():
+        global _RUNNING
+        try:
+            if mode == "hermes":
+                subprocess.run(["hermes", "-z", HERMES_PROMPT,
+                                "--skill", "fantasy-manager"])
+            else:
+                subprocess.run([sys.executable, "-m", "fantasybot", "agent", "--execute"])
+        finally:
+            _RUNNING = False
+
+    _RUNNING = True
+    threading.Thread(target=go, daemon=True).start()
+    return True
 
 
 class Handler(http.server.BaseHTTPRequestHandler):
@@ -98,24 +130,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
     def _run(self):
         """Launches the real agent cycle (the 'Launch agent' button)."""
-        global _RUNNING
-        if _RUNNING:
-            return self._send(409, "application/json", b'{"error":"already running"}')
         mode = getattr(self.server, "run_mode", "agent")
-
-        def go():
-            global _RUNNING
-            try:
-                if mode == "hermes":
-                    subprocess.run(["hermes", "-z", HERMES_PROMPT,
-                                    "--skill", "fantasy-manager"])
-                else:
-                    subprocess.run([sys.executable, "-m", "fantasybot", "agent", "--execute"])
-            finally:
-                _RUNNING = False
-
-        _RUNNING = True
-        threading.Thread(target=go, daemon=True).start()
+        if not trigger(mode):
+            return self._send(409, "application/json", b'{"error":"already running"}')
         self._send(202, "application/json", b'{"ok":true}')
 
     def _page(self):


### PR DESCRIPTION
## Summary

Found these while running `fantasybot watch --hermes` live on Windows for the first time (fresh Hermes install, `hermes gateway install` + crons per `deploy/`):

- **`agent.py` / `cli.py`** — `fantasybot agent` (and the Hermes `fantasy-manager` skill cycle that calls it) crashed with an unhandled `ValueError: Not enough players for any valid formation` whenever the squad is too thin for any legal formation (e.g. early season, right after selling players). One bad review would take down the whole cycle instead of just skipping the lineup step. Now it degrades gracefully: lineup optimization is skipped for that run and the report/CLI output an explicit `lineup.error` instead of crashing.

- **`monitor.py`** — the dashboard's periodic `/insights` poll (every 20s) shells out to `hermes insights` via `subprocess.run(..., text=True)`, which decodes stdout using the platform's default codepage. On Windows that's `cp1252`, which can't decode some bytes `hermes insights` prints (emoji/box-drawing), crashing the subprocess reader thread with `UnicodeDecodeError` and turning into a `TypeError: expected string or bytes-like object, got 'NoneType'` in `_insights()` every ~20 seconds. Fixed by decoding as UTF-8 with `errors="replace"`.

- **`monitor.py` / `cli.py`** — `fantasybot watch --hermes`/`--run` fired its agent cycle via its own unguarded `subprocess.run` call in `cmd_watch`'s `fire()`, completely bypassing the `_RUNNING` lock that only protected the dashboard's "Launch agent" button (`POST /run`). A concurrent trigger (the button racing the CLI's auto-fire on startup, or two `watch` processes pointed at the same team) could fire two real, money-spending agent cycles at once with no mutual exclusion. Extracted a single `monitor.trigger(mode)` helper (still guarded by `_RUNNING`) and routed both the button and the CLI auto-fire through it, so only one cycle can run at a time regardless of trigger source.

No behavior change for the common case (healthy squad, single trigger) — these only kick in on the edge cases above.

## Test plan
- [x] `python -m fantasybot watch --hermes` on Windows: dashboard loads, `/insights` polling no longer throws, agent cycle completes without a raw traceback even against a squad below the minimum formation size
- [ ] `python -c "import ast; ast.parse(...)"` + `python -c "import fantasybot.monitor, fantasybot.cli"` — both modules still parse/import cleanly
- [ ] Not tested: the "Launch agent" button racing a CLI `--hermes` auto-fire concurrently (the guard is straightforward, but I didn't reproduce the exact race)