### PR TITLE
fix: don't propose bids on players that already have money on them

### DIFF
--- a/fantasybot/execute.py
+++ b/fantasybot/execute.py
@@ -43,11 +43,21 @@ def plan_bids(client, league_id, team, ops=None):
     money = team["teamMoney"]
     if ops is None:
         ops = _system_flips(client, league_id)
-    already = state.load_bids()
+    # The live market is the truth about what already has money on it, not the local
+    # file. The file only remembers THIS bot's bids: anything placed from the app or
+    # by hand is invisible to it, and the bot re-proposes players that already carry
+    # a bid. Reading `bid`/`offer` off each listing catches them all.
+    already = set(state.load_bids())
+    try:
+        for el in client.market(league_id):
+            if el.get("bid") or el.get("offer"):
+                already.add(str(el.get("id")))
+    except Exception:
+        pass          # without the market, the local file is still better than nothing
     plan, committed = [], 0
     for o in ops:
-        if o["market_id"] in already:
-            continue  # we already have a bid
+        if str(o["market_id"]) in already:
+            continue  # money is already on that player
         if committed + o["buy_price"] > money:
             continue  # doesn't fit in the balance
         plan.append({"market_id": o["market_id"], "nombre": o["nombre"],

--- a/tests/test_no_reproposal.py
+++ b/tests/test_no_reproposal.py
@@ -1,0 +1,68 @@
+"""Regression: the bot must not propose bidding on a player who already has money on him.
+
+The local bids file only remembers THIS bot's bids. Anything placed from the official
+app (or by hand from the CLI on another machine) is invisible to it, so `plan_bids`
+kept re-proposing players the manager had already bid on — in a real league, 4 of 7
+proposals were things already done, which makes the other 3 look untrustworthy too.
+The live market is the truth: every listing carries its own `bid`/`offer` when money
+is on it, whoever placed it.
+"""
+
+import os
+import tempfile
+import unittest
+
+os.environ["FANTASYBOT_HOME"] = tempfile.mkdtemp(prefix="fb-noreprop-")
+
+from fantasybot import execute  # noqa: E402
+
+
+class _Client:
+    """Network-free stand-in: a market where Aubameyang already has OUR bid."""
+
+    def __init__(self, entries):
+        self._entries = entries
+
+    def market(self, league_id):
+        return self._entries
+
+
+_TEAM = {"teamMoney": 100_000_000}
+
+_OPS = [
+    {"market_id": "1", "nombre": "Aubameyang", "buy_price": 31_000_000,
+     "margin_pct": 5.0, "via": "SISTEMA"},
+    {"market_id": "3", "nombre": "Libre", "buy_price": 1_000_000,
+     "margin_pct": 8.0, "via": "SISTEMA"},
+]
+
+
+class PlanRespectsLiveBids(unittest.TestCase):
+    def test_listing_with_a_live_bid_is_skipped(self):
+        client = _Client([
+            {"id": 1, "bid": {"id": "b1", "money": 31_000_000, "status": "pending"}},
+            {"id": 3},
+        ])
+        plan = execute.plan_bids(client, "L", _TEAM, ops=_OPS)
+        self.assertEqual([p["nombre"] for p in plan], ["Libre"])
+
+    def test_an_offer_to_a_manager_counts_the_same(self):
+        # Different endpoint, different field — but the money is just as committed.
+        client = _Client([
+            {"id": 1, "offer": {"id": "o1", "money": 31_000_000, "status": "pending"}},
+            {"id": 3},
+        ])
+        plan = execute.plan_bids(client, "L", _TEAM, ops=_OPS)
+        self.assertEqual([p["nombre"] for p in plan], ["Libre"])
+
+    def test_market_failure_degrades_to_the_local_file(self):
+        class _Broken(_Client):
+            def market(self, league_id):
+                raise RuntimeError("market down")
+
+        plan = execute.plan_bids(_Broken([]), "L", _TEAM, ops=_OPS)
+        self.assertEqual(len(plan), 2)  # no crash: local file (empty) still applies
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The local bids file only remembers this bot's own bids, so anything placed from the official app (or by hand) was invisible and plan_bids kept re-proposing players the manager had already bid on. Read the live market's bid/offer fields — the truth about committed money, whoever placed it — and skip those listings. Degrades to the local file if the market call fails.


Claude-Session: https://claude.ai/code/session_013AYRtpqF23ThUDGWE7egms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate proposals for players who already have active bids or offers in the live market.
  - Added fallback behavior so proposal planning continues using locally stored bid data when live market information is unavailable.

- **Tests**
  - Added coverage for live bids, live offers, and market retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->