### PR TITLE
feat: when a rival's player is on sale, recommend the bid, not the cl…

### DIFF
--- a/fantasybot/agent.py
+++ b/fantasybot/agent.py
@@ -66,6 +66,11 @@ def clause_targets(market, team, prob_index):
         prob = info.get("prob") if info else None
         if prob is not None and prob < MIN_CLAUSE_PROB:
             continue  # benchwarmer: a buyout on him is wasted money, don't recommend it
+        # If his owner already has him ON SALE, bidding is the cheaper way in: the
+        # clause is a ~1.67x premium and it is locked for days, while the sale is open
+        # now and starts at his value. Recommending the clause without checking this
+        # is how you end up paying 4.5M for a keeper listed at 2.7M.
+        on_sale = el.get("salePrice") if el.get("status") == "on_sale" else None
         targets.append({
             "nombre": pm.get("nickname") or pm.get("name"),
             "player_id": pm["id"],
@@ -74,6 +79,12 @@ def clause_targets(market, team, prob_index):
             "unlock": unlock,
             "prob": prob,
             "reason": f"fills a {pos} gap",
+            # cheaper route, when there is one
+            "market_id": el.get("id") if on_sale else None,
+            "sale_price": on_sale,
+            "sale_expires": el.get("expirationDate") if on_sale else None,
+            "cheaper_via_bid": bool(on_sale and on_sale < clause),
+            "saving_vs_clause": (clause - on_sale) if (on_sale and on_sale < clause) else 0,
         })
     targets.sort(key=lambda t: (t["prob"] or 0), reverse=True)
     return targets
@@ -90,9 +101,16 @@ def _sync_tasks(gaps, targets, sells, lineup_changed):
             state.complete_by_key(key)
     # buyout targets (and close the ones that no longer apply)
     for t in targets:
-        state.add_task(
-            f"Buyout {t['nombre']} ({t['pos']}) for {t['clause']:,} "
-            f"when its clause opens.", due=t["unlock"], key=f"clause:{t['player_id']}")
+        if t.get("cheaper_via_bid"):
+            text = (f"Bid for {t['nombre']} ({t['pos']}): he's ON SALE at "
+                    f"{t['sale_price']:,}, {t['saving_vs_clause']:,} less than his "
+                    f"{t['clause']:,} clause. Closes {t['sale_expires']}.")
+            due = t["sale_expires"]
+        else:
+            text = (f"Buyout {t['nombre']} ({t['pos']}) for {t['clause']:,} "
+                    f"when its clause opens.")
+            due = t["unlock"]
+        state.add_task(text, due=due, key=f"clause:{t['player_id']}")
     state.complete_missing("clause:", {f"clause:{t['player_id']}" for t in targets})
     # recommended sales
     for s in sells:

--- a/fantasybot/agent.py
+++ b/fantasybot/agent.py
@@ -58,19 +58,24 @@ def clause_targets(market, team, prob_index):
         if pm["id"] in owned:
             continue
         pos = POS.get(pm.get("positionId"))
+        if pos not in gap_positions:
+            continue
         pt = el.get("playerTeam", {})
         clause, unlock = pt.get("buyoutClause"), pt.get("buyoutClauseLockedEndTime")
-        if not (clause and unlock and pos in gap_positions and clause <= money):
+        # If his owner already has him ON SALE, bidding is the cheaper way in: the
+        # clause is a ~1.67x premium and it is locked for days, while the sale is open
+        # now and starts at his value. The sale is a DOOR OF ITS OWN: gating on an
+        # affordable clause first priced reachable listings out of the report just
+        # because their (irrelevant) clause was rich.
+        on_sale = el.get("salePrice") if el.get("status") == "on_sale" else None
+        via_clausula = bool(clause and unlock and clause <= money)
+        via_puja = bool(on_sale and on_sale <= money)
+        if not (via_clausula or via_puja):
             continue
         info = match_name(pm.get("nickname", ""), pm.get("name", ""), prob_index)
         prob = info.get("prob") if info else None
         if prob is not None and prob < MIN_CLAUSE_PROB:
-            continue  # benchwarmer: a buyout on him is wasted money, don't recommend it
-        # If his owner already has him ON SALE, bidding is the cheaper way in: the
-        # clause is a ~1.67x premium and it is locked for days, while the sale is open
-        # now and starts at his value. Recommending the clause without checking this
-        # is how you end up paying 4.5M for a keeper listed at 2.7M.
-        on_sale = el.get("salePrice") if el.get("status") == "on_sale" else None
+            continue  # benchwarmer: signing him by any route is wasted money
         targets.append({
             "nombre": pm.get("nickname") or pm.get("name"),
             "player_id": pm["id"],
@@ -83,8 +88,10 @@ def clause_targets(market, team, prob_index):
             "market_id": el.get("id") if on_sale else None,
             "sale_price": on_sale,
             "sale_expires": el.get("expirationDate") if on_sale else None,
-            "cheaper_via_bid": bool(on_sale and on_sale < clause),
-            "saving_vs_clause": (clause - on_sale) if (on_sale and on_sale < clause) else 0,
+            "cheaper_via_bid": bool(on_sale and via_puja
+                                    and (not via_clausula or on_sale < clause)),
+            "saving_vs_clause": ((clause - on_sale)
+                                 if (clause and on_sale and on_sale < clause) else 0),
         })
     targets.sort(key=lambda t: (t["prob"] or 0), reverse=True)
     return targets
@@ -212,6 +219,9 @@ def review(client, days_to_matchday=None):
                 "message": "Market closes in 5 min: review bids and needs.",
             })
     for t in targets:
+        if t.get("cheaper_via_bid"):
+            continue   # the recommended route is the OPEN SALE; a "prepare the
+                       # buyout" alarm for the same player contradicts the task
         dt = _parse(t["unlock"])
         if dt:
             reminders.append({

--- a/fantasybot/state.py
+++ b/fantasybot/state.py
@@ -109,10 +109,19 @@ def _next_id(tasks):
 
 
 def add_task(text: str, due=None, key=None) -> dict:
-    """Add a task. `key` prevents duplicates (same key = not repeated)."""
+    """Add a task. `key` prevents duplicates (same key = not repeated).
+
+    A re-added key REFRESHES text and due date: a task's identity is its key, but
+    its content follows the world — when a target's acquisition route changes
+    (clause -> open sale), keeping the old wording pinned a stale price and a
+    stale deadline on screen."""
     tasks = load_tasks()
     if key and any(t.get("key") == key for t in tasks):
-        return next(t for t in tasks if t.get("key") == key)
+        task = next(t for t in tasks if t.get("key") == key)
+        if task.get("text") != text or task.get("due") != due:
+            task["text"], task["due"] = text, due
+            save_tasks(tasks)
+        return task
     task = {"id": _next_id(tasks), "text": text, "due": due, "key": key,
             "done": False, "created": int(time.time())}
     tasks.append(task)

--- a/fantasybot/strategy/needs.py
+++ b/fantasybot/strategy/needs.py
@@ -63,10 +63,20 @@ def candidates(client, league_id, position, prob_index=None, money=None, owned=N
             continue
         if pm.get("id") in owned:
             continue  # already yours
+        clause = sale = None
         if el["discr"] == "marketPlayerLeague":
             via, price = "SISTEMA", el.get("salePrice") or pm.get("marketValue")
         else:
-            via, price = "CLAUSULA", el.get("playerTeam", {}).get("buyoutClause")
+            clause = el.get("playerTeam", {}).get("buyoutClause")
+            # A player another manager has listed can simply be BID for, at his sale
+            # price. That is nearly always cheaper than his clause (~1.67x value) and
+            # available now instead of when the lock expires. Offering only the clause
+            # here was overpricing every signing from another squad.
+            sale = el.get("salePrice") if el.get("status") == "on_sale" else None
+            if sale and (clause is None or sale < clause):
+                via, price = "PUJA", sale
+            else:
+                via, price = "CLAUSULA", clause
         if not price:
             continue
         info = match_name(pm.get("nickname", ""), pm.get("name", ""), prob_index)
@@ -84,6 +94,10 @@ def candidates(client, league_id, position, prob_index=None, money=None, owned=N
             "disponible": disponible,
             "valor": pm.get("marketValue"),
             "affordable": (money is None or price <= money),
+            # both routes, so the caller can see what the alternative would have cost
+            "clause": clause,
+            "sale_price": sale,
+            "expires": el.get("expirationDate"),
         })
     # sort: available starters first, then by probability and value
     out.sort(key=lambda c: (c["disponible"], c["prob"] or 0, c["valor"] or 0),
@@ -101,7 +115,9 @@ def advise(client, league_id, team, days_to_matchday=None):
     for pos in report["gaps"]:
         cands = candidates(client, league_id, pos, prob_index, money, owned)
         for c in cands:
-            # recommended bid cap: price, raised by urgency (system only)
-            c["max_bid"] = round(c["price"] * mult) if c["via"] == "SISTEMA" else c["price"]
+            # recommended cap: the price, raised by urgency when there is bidding
+            # involved. A clause is a fixed amount — urgency cannot change it.
+            c["max_bid"] = (round(c["price"] * mult)
+                            if c["via"] in ("SISTEMA", "PUJA") else c["price"])
         report["suggestions"][pos] = cands
     return report

--- a/tests/test_cheaper_than_clause.py
+++ b/tests/test_cheaper_than_clause.py
@@ -1,0 +1,88 @@
+"""Regression: when a rival's player is ON SALE, recommend the bid, not the clause.
+
+A clause is a ~1.67x premium over value and stays locked for days; a sale listing is
+open right now and starts at his value. The advisor used to offer only the clause
+route for players owned by other managers — recommending a 4.5M buyout on a keeper
+his owner had listed at 2.7M. When both routes exist, the cheaper one wins, and the
+report still carries both prices so the caller can see the alternative.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+os.environ["FANTASYBOT_HOME"] = tempfile.mkdtemp(prefix="fb-cheaper-")
+
+from fantasybot import agent  # noqa: E402
+from fantasybot.strategy import needs  # noqa: E402
+
+
+def _keeper(status=None, sale=None):
+    el = {"discr": "marketPlayerTeam", "id": "m9",
+          "playerMaster": {"id": "pK", "nickname": "Portero", "name": "Un Portero",
+                           "positionId": 1, "marketValue": 2_700_000,
+                           "playerStatus": "ok"},
+          "playerTeam": {"buyoutClause": 4_500_000,
+                         "buyoutClauseLockedEndTime": "2026-09-01T21:00:00+02:00"},
+          "expirationDate": "2026-08-23T14:00:00+02:00"}
+    if status:
+        el["status"] = status
+    if sale is not None:
+        el["salePrice"] = sale
+    return el
+
+
+class _Client:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def market(self, league_id):
+        return self._entries
+
+
+_TEAM = {"teamMoney": 100_000_000, "players": []}
+
+
+class CandidatesPreferTheCheaperRoute(unittest.TestCase):
+    def test_on_sale_beats_the_clause(self):
+        cands = needs.candidates(_Client([_keeper("on_sale", 2_700_000)]), "L",
+                                 "POR", prob_index={}, money=100_000_000)
+        self.assertEqual(cands[0]["via"], "PUJA")
+        self.assertEqual(cands[0]["price"], 2_700_000)
+        self.assertEqual(cands[0]["clause"], 4_500_000)  # the alternative, visible
+
+    def test_not_on_sale_keeps_the_clause_route(self):
+        cands = needs.candidates(_Client([_keeper()]), "L",
+                                 "POR", prob_index={}, money=100_000_000)
+        self.assertEqual(cands[0]["via"], "CLAUSULA")
+        self.assertEqual(cands[0]["price"], 4_500_000)
+
+    def test_urgency_raises_the_bid_cap_but_never_the_clause(self):
+        client = _Client([_keeper("on_sale", 2_700_000)])
+        with mock.patch.object(needs, "gaps", lambda t: ["POR"]), \
+             mock.patch.object(needs, "probable_lineups", lambda: {}):
+            report = needs.advise(client, "L", _TEAM, days_to_matchday=0.5)
+        c = report["suggestions"]["POR"][0]
+        self.assertGreater(c["max_bid"], c["price"])  # PUJA: urgency applies
+
+
+class ClauseTargetsFlagTheCheaperRoute(unittest.TestCase):
+    def setUp(self):
+        p = mock.patch.object(agent.needs_mod, "gaps", lambda t: ["POR"])
+        p.start()
+        self.addCleanup(p.stop)
+
+    def test_target_carries_the_saving(self):
+        targets = agent.clause_targets([_keeper("on_sale", 2_700_000)], _TEAM, {})
+        self.assertTrue(targets[0]["cheaper_via_bid"])
+        self.assertEqual(targets[0]["saving_vs_clause"], 1_800_000)
+
+    def test_no_sale_no_flag(self):
+        targets = agent.clause_targets([_keeper()], _TEAM, {})
+        self.assertFalse(targets[0]["cheaper_via_bid"])
+        self.assertEqual(targets[0]["saving_vs_clause"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cheaper_than_clause.py
+++ b/tests/test_cheaper_than_clause.py
@@ -86,3 +86,31 @@ class ClauseTargetsFlagTheCheaperRoute(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ReviewFeedbackRegressions(unittest.TestCase):
+    """The three review findings on this PR, frozen as tests."""
+
+    def test_venta_alcanzable_con_clausula_impagable(self):
+        # An affordable open sale must surface even when the clause is out of reach.
+        el = _keeper("on_sale", 2_700_000)
+        el["playerTeam"]["buyoutClause"] = 900_000_000   # nadie paga eso
+        with mock.patch.object(agent.needs_mod, "gaps", lambda t: ["POR"]):
+            targets = agent.clause_targets([el], _TEAM, {})
+        self.assertEqual(len(targets), 1)
+        self.assertTrue(targets[0]["cheaper_via_bid"])
+
+    def test_add_task_refresca_texto_y_fecha_con_la_misma_clave(self):
+        import os, tempfile
+        from fantasybot import state
+        old = state.TASKS_PATH
+        state.TASKS_PATH = os.path.join(tempfile.mkdtemp(), "tasks.json")
+        try:
+            state.add_task("Buyout X for 4,500,000", due="2026-09-01", key="clause:x")
+            t = state.add_task("Bid for X: ON SALE at 2,700,000",
+                               due="2026-08-25", key="clause:x")
+            self.assertEqual(t["text"], "Bid for X: ON SALE at 2,700,000")
+            self.assertEqual(t["due"], "2026-08-25")
+            self.assertEqual(len(state.load_tasks()), 1)   # misma tarea, no otra
+        finally:
+            state.TASKS_PATH = old


### PR DESCRIPTION
…ause

A clause is a ~1.67x premium and stays locked for days; a sale listing is open now and starts at his value. The advisor offered only the clause route for players owned by other managers — recommending a 4.5M buyout on a keeper his owner had listed at 2.7M. Now the cheaper route wins (needs.candidates: via PUJA; agent.clause_targets: cheaper_via_bid + saving), urgency raises the bid cap but never a clause, and the report keeps both prices visible.


Claude-Session: https://claude.ai/code/session_013AYRtpqF23ThUDGWE7egms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Players listed for sale can now be acquired through a bid when it costs less than the buyout clause.
  * Purchase recommendations show sale price, expiration, potential savings, and the preferred acquisition route.
  * Automated tasks now account for sale bids, deadlines, and updated recommendations.

* **Bug Fixes**
  * Urgency-based bid limits now apply appropriately to market and auction purchases without affecting fixed buyout clauses.
  * Existing tasks now refresh when their details change.

* **Tests**
  * Added coverage for sale bids, buyout alternatives, savings, deadlines, task updates, and urgency-based bidding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->