### PR TITLE
test(cheaper-route): collect all cases under direct invocation (PR #4 follow-up)

### DIFF
--- a/tests/test_cheaper_than_clause.py
+++ b/tests/test_cheaper_than_clause.py
@@ -84,10 +84,6 @@ class ClauseTargetsFlagTheCheaperRoute(unittest.TestCase):
         self.assertEqual(targets[0]["saving_vs_clause"], 0)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class ReviewFeedbackRegressions(unittest.TestCase):
     """The three review findings on this PR, frozen as tests."""
 
@@ -114,3 +110,7 @@ class ReviewFeedbackRegressions(unittest.TestCase):
             self.assertEqual(len(state.load_tasks()), 1)   # misma tarea, no otra
         finally:
             state.TASKS_PATH = old
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Minor housekeeping on the tests added in #4. The two `ReviewFeedbackRegressions` cases sat after the `if __name__ == "__main__": unittest.main()` block, so only `unittest discover` (CI) collected them; a direct `python <file>` run stopped before them. Moves the guard to the end. No production code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test runner ordering so all regression tests are defined before direct execution.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->