### PR TITLE
fix(net): pace requests to the scraped site, one at a time

### DIFF
--- a/fantasybot/net.py
+++ b/fantasybot/net.py
@@ -1,20 +1,50 @@
 """Polite HTTP fetching: retries on 429 while honoring Retry-After.
 
-Adds no artificial waits: it only waits if the server throttles us (429). This
-way it doesn't get in the way of urgent actions but avoids bans from overload.
+Two courtesies, and only where they're owed:
+
+- On 429 it waits (Retry-After or backoff) and retries. No artificial delay for
+  anyone else, so urgent API actions stay fast.
+- futbolfantasy gets a PACING floor: at most one request every THROTTLE seconds
+  across ALL threads. The day the panel grew match pages and probable lineups,
+  parallel workers hammered them into rate-limiting us (429s all over the
+  console) — being scraped is a favor, and favors get queued politely.
 """
 
+import threading
 import time
 import urllib.error
 import urllib.request
+from urllib.parse import urlsplit
 
 from . import config
+
+THROTTLE_HOSTS = ("futbolfantasy.com",)
+THROTTLE_SECONDS = 1.2
+_pace_lock = threading.Lock()
+_last_hit = {}
+
+
+def _pace(url):
+    """Blocks until this host's turn. Cheap no-op for everyone not throttled."""
+    host = urlsplit(url).netloc.lower()
+    if not any(host.endswith(h) for h in THROTTLE_HOSTS):
+        return
+    while True:
+        with _pace_lock:
+            ahora = time.monotonic()
+            libre = _last_hit.get("ff", 0) + THROTTLE_SECONDS
+            if ahora >= libre:
+                _last_hit["ff"] = ahora
+                return
+            espera = libre - ahora
+        time.sleep(espera)
 
 
 def get(url: str, timeout: int = 20, retries: int = 3) -> str:
     """Fetches text. On 429, waits (Retry-After or backoff) and retries."""
     delay = 2
     for attempt in range(retries + 1):
+        _pace(url)
         req = urllib.request.Request(url, headers={"User-Agent": config.USER_AGENT})
         try:
             with urllib.request.urlopen(req, timeout=timeout) as r:

--- a/tests/test_net_pacing.py
+++ b/tests/test_net_pacing.py
@@ -1,0 +1,51 @@
+"""Regression: the scraped site gets a pacing floor, the API does not.
+
+Parallel workers fetching match pages and probable lineups hammered
+futbolfantasy into rate-limiting us. One request at a time, spaced, keeps the
+scrape welcome — while API calls, which are urgent, stay at full speed.
+"""
+
+import unittest
+from unittest import mock
+
+from fantasybot import net
+
+
+class PacingIsOnlyForTheScrapedSite(unittest.TestCase):
+
+    def setUp(self):
+        net._last_hit.clear()
+        self.addCleanup(net._last_hit.clear)
+
+    def _waits_for(self, url, calls=2):
+        """Seconds slept across `calls` consecutive fetches of the same host."""
+        reloj = {"t": 100.0}
+        dormido = []
+
+        def fake_sleep(segundos):
+            dormido.append(segundos)
+            reloj["t"] += segundos
+
+        with mock.patch.object(net.time, "monotonic", lambda: reloj["t"]), \
+             mock.patch.object(net.time, "sleep", fake_sleep):
+            for _ in range(calls):
+                net._pace(url)
+        return dormido
+
+    def test_second_hit_on_the_scraped_site_waits(self):
+        dormido = self._waits_for("https://www.futbolfantasy.com/partidos/x")
+        self.assertEqual(len(dormido), 1)
+        self.assertAlmostEqual(sum(dormido), net.THROTTLE_SECONDS, places=6)
+
+    def test_the_api_is_never_slowed_down(self):
+        # An urgent bid must not queue behind a scrape.
+        self.assertEqual(
+            self._waits_for("https://api.laligafantasymarca.com/stats/v1/x", calls=5),
+            [])
+
+    def test_subdomains_of_a_throttled_host_are_throttled_too(self):
+        self.assertEqual(len(self._waits_for("https://cdn.futbolfantasy.com/a.png")), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The day the panel grew match pages and probable lineups, parallel workers fetched futbolfantasy concurrently and it started rate-limiting us: 429s all over the console, and every retry made it worse.

net.get() now enforces a pacing floor of one request every 1.2s to that host, shared across ALL threads. The API is untouched: an urgent bid must never queue behind a scrape, so the floor applies to THROTTLE_HOSTS only.

Regression tests cover the three cases: the second scrape waits, the API never waits however many calls, and subdomains of a throttled host are throttled too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request pacing for futbolfantasy.com and its subdomains to help prevent excessive request rates.
  * Requests to other services remain unaffected.
  * Existing retry handling for rate-limit responses is unchanged.

* **Tests**
  * Added coverage verifying pacing behavior across repeated website requests and unrestricted API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->