### PR TITLE
fix(monitor): a closed browser tab is not a crash

### DIFF
--- a/fantasybot/monitor.py
+++ b/fantasybot/monitor.py
@@ -188,6 +188,16 @@ class _Server(http.server.ThreadingHTTPServer):
     allow_reuse_address = True
     run_mode = "agent"
 
+    def handle_error(self, request, client_address):
+        """A browser slamming a connection shut mid-request is Tuesday, not an
+        emergency: without this, every closed tab printed a full traceback to the
+        console and read like the bot had crashed. Real errors still print."""
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionResetError, ConnectionAbortedError,
+                            BrokenPipeError, TimeoutError)):
+            return
+        super().handle_error(request, client_address)
+
 
 def serve(host=DEFAULT_HOST, port=DEFAULT_PORT, background=False, run_mode="agent"):
     """Starts the server. Returns (server, url). With background=True, non-blocking.

--- a/tests/test_monitor_quiet_disconnects.py
+++ b/tests/test_monitor_quiet_disconnects.py
@@ -1,0 +1,41 @@
+"""Regression: a closed browser tab is not an error worth printing.
+
+The panel is watched from a console window. Every time a tab was closed while a
+request was in flight, the socket error surfaced as a full traceback and read
+like the bot had crashed. Silencing the disconnect family keeps that window
+trustworthy — a traceback there must always mean something is actually wrong.
+"""
+
+import http.server
+import unittest
+from unittest import mock
+
+from fantasybot import monitor
+
+
+class ClientDisconnectsAreSilent(unittest.TestCase):
+
+    def _handled_by_the_parent(self, exc):
+        """True if the default (printing) handler was reached for `exc`."""
+        srv = object.__new__(monitor._Server)     # no socket, no bind
+        printed = []
+        with mock.patch.object(http.server.ThreadingHTTPServer, "handle_error",
+                               lambda self, request, client_address: printed.append(1)):
+            try:
+                raise exc
+            except type(exc):
+                srv.handle_error(None, ("127.0.0.1", 51234))
+        return bool(printed)
+
+    def test_a_closed_tab_prints_nothing(self):
+        for exc in (ConnectionResetError(), ConnectionAbortedError(),
+                    BrokenPipeError(), TimeoutError()):
+            with self.subTest(exc=type(exc).__name__):
+                self.assertFalse(self._handled_by_the_parent(exc))
+
+    def test_a_real_bug_still_prints(self):
+        self.assertTrue(self._handled_by_the_parent(ValueError("a real bug")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The panel is watched from a console window. Closing a tab mid-request raised the socket error up to BaseServer.handle_error, which printed a full traceback -- indistinguishable, at a glance, from the bot actually falling over.

_Server.handle_error now swallows the disconnect family (reset, abort, broken pipe, timeout) and delegates everything else to the default handler, so a traceback in that window still means something is genuinely wrong.

Regression tests pin both halves: the four disconnect errors print nothing, a ValueError still reaches the parent handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented expected client disconnections from displaying unnecessary error tracebacks.
  * Preserved standard error reporting for unexpected failures.

* **Tests**
  * Added coverage confirming quiet handling for closed connections and continued reporting of genuine errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->