### PR TITLE
fix(auth): time out the token request instead of hanging forever

### DIFF
--- a/fantasybot/auth.py
+++ b/fantasybot/auth.py
@@ -103,7 +103,9 @@ def _post_token(body: dict) -> dict:
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         method="POST")
     try:
-        with urllib.request.urlopen(req) as resp:
+        # Without a timeout a stalled token refresh hangs the caller forever; a
+        # cron-driven bid run wedged this way once and never placed its bids.
+        with urllib.request.urlopen(req, timeout=30) as resp:
             return json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         detail = e.read().decode("utf-8", "replace")


### PR DESCRIPTION
`_post_token` was the only network call in the package without a timeout (`net.get` already uses 20s). When the B2C token endpoint stalled, the refresh hung and everything behind it hung too: a cron-driven `bid-run` sat there past market close and never placed its bids, with nothing in the log to show why. 30 seconds is generous for a token exchange and turns the hang into a `URLError` the caller can see.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 30-second timeout to authentication and token refresh requests, preventing them from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->