### PR TITLE
fix(matching): match nickname tokens against whole words, not substrings

### DIFF
--- a/fantasybot/matching.py
+++ b/fantasybot/matching.py
@@ -5,6 +5,7 @@ The LaLiga API uses nicknames ("Etta Eyong") and futbolfantasy uses full names
 in several places.
 """
 
+import itertools
 import unicodedata
 
 # API positions (positionId -> abbreviation). Shared by the strategies.
@@ -28,7 +29,7 @@ def match_name(nickname: str, full_name: str, index: dict):
     """Finds the `index` entry for a player from the LaLiga API.
 
     Tries an exact match by nickname and by full name; if that fails, by tokens
-    (all the significant tokens of the nickname appear in the key).
+    (every significant token of the nickname is found in the key, in order).
     Returns the entry or None.
     """
     nick = normalize(nickname)
@@ -37,25 +38,50 @@ def match_name(nickname: str, full_name: str, index: dict):
         return index[nick]
     if full in index:
         return index[full]
-    tokens = [t for t in nick.split() if len(t) > 2]
+    tokens = [t for t in nick.split() if len(t) > 2 or _is_initial(t)]
     if tokens:
         # Only trust a token match if it's UNIQUE. A short/common nickname
         # ("Pedro", "Álvarez") is a subset of several names; returning an arbitrary
         # one is a false positive (what SANITY_MAX_DIFF in flip.py papers over).
         # Ambiguous -> no confident match. The ID crosswalk is the real fix.
         hits = [value for key, value in index.items()
-                if all(_token_matches(t, key.split()) for t in tokens)]
+                if _tokens_match(tokens, key.split())]
         if len(hits) == 1:
             return hits[0]
     return None
 
 
-def _token_matches(token, words):
-    """Whole-word match; substrings only between long tokens ("Oskarsson" vs
-    "skarsson"). Plain substring made "Oso" match "johnny cardoso"."""
-    for w in words:
-        if token == w:
-            return True
-        if len(token) >= 5 and len(w) >= 5 and (token in w or w in token):
-            return True
-    return False
+def _is_initial(token):
+    return len(token) == 2 and token[1] == "." and token[0].isalpha()
+
+
+def _tokens_match(tokens, words):
+    """True if the nickname tokens are found in the key's words, in order.
+
+    A name token equals a word or, from 4 chars, is a prefix of one ("Javi" ->
+    javier, "Alti" -> altimira). Substrings are not trusted: "Oso" is inside
+    cardOSO and OSOrio, and "pedro" inside pedrosa turned unique hits into
+    ambiguous ones. Leading initials ("C. Alvarez") must agree with a word
+    before the first name match and trailing ones ("John C.") with a word after
+    the last; a middle initial ("Pathé I. Ciss") says nothing. When the key has
+    no word left over, initials are not checked ("R. Terrats" -> terrats)."""
+    names = [t for t in tokens if not _is_initial(t)]
+    if not names:
+        return False
+    pos = 0
+    first = None
+    for t in names:
+        while pos < len(words) and not (
+                t == words[pos] or (len(t) >= 4 and words[pos].startswith(t))):
+            pos += 1
+        if pos == len(words):
+            return False
+        if first is None:
+            first = pos
+        pos += 1
+    if len(words) == len(names):
+        return True
+    lead = [t[0] for t in itertools.takewhile(_is_initial, tokens)]
+    trail = [t[0] for t in itertools.takewhile(_is_initial, reversed(tokens))]
+    return (all(any(w[0] == c for w in words[:first]) for c in lead)
+            and all(any(w[0] == c for w in words[pos:]) for c in trail))

--- a/fantasybot/matching.py
+++ b/fantasybot/matching.py
@@ -63,8 +63,8 @@ def _tokens_match(tokens, words):
     cardOSO and OSOrio, and "pedro" inside pedrosa turned unique hits into
     ambiguous ones. Leading initials ("C. Alvarez") must agree with a word
     before the first name match and trailing ones ("John C.") with a word after
-    the last; a middle initial ("Pathé I. Ciss") says nothing. When the key has
-    no word left over, initials are not checked ("R. Terrats" -> terrats)."""
+    the last; a middle initial ("Pathé I. Ciss") says nothing. A single-word
+    key has nothing to check initials against ("R. Terrats" -> terrats)."""
     names = [t for t in tokens if not _is_initial(t)]
     if not names:
         return False
@@ -79,9 +79,16 @@ def _tokens_match(tokens, words):
         if first is None:
             first = pos
         pos += 1
-    if len(words) == len(names):
+    if len(words) == 1:
         return True
-    lead = [t[0] for t in itertools.takewhile(_is_initial, tokens)]
-    trail = [t[0] for t in itertools.takewhile(_is_initial, reversed(tokens))]
-    return (all(any(w[0] == c for w in words[:first]) for c in lead)
-            and all(any(w[0] == c for w in words[pos:]) for c in trail))
+    lead = list(itertools.takewhile(_is_initial, tokens))
+    trail = list(itertools.takewhile(_is_initial, reversed(tokens)))[::-1]
+    return (_initials_in_order(lead, words[:first])
+            and _initials_in_order(trail, words[pos:]))
+
+
+def _initials_in_order(initials, words):
+    """Each initial takes a distinct word, in order ("D. C." needs a d-word and
+    then a c-word after it)."""
+    it = iter(words)
+    return all(any(w[0] == t[0] for w in it) for t in initials)

--- a/fantasybot/matching.py
+++ b/fantasybot/matching.py
@@ -44,7 +44,18 @@ def match_name(nickname: str, full_name: str, index: dict):
         # one is a false positive (what SANITY_MAX_DIFF in flip.py papers over).
         # Ambiguous -> no confident match. The ID crosswalk is the real fix.
         hits = [value for key, value in index.items()
-                if all(t in key for t in tokens)]
+                if all(_token_matches(t, key.split()) for t in tokens)]
         if len(hits) == 1:
             return hits[0]
     return None
+
+
+def _token_matches(token, words):
+    """Whole-word match; substrings only between long tokens ("Oskarsson" vs
+    "skarsson"). Plain substring made "Oso" match "johnny cardoso"."""
+    for w in words:
+        if token == w:
+            return True
+        if len(token) >= 5 and len(w) >= 5 and (token in w or w in token):
+            return True
+    return False

--- a/tests/test_matching_ambiguous.py
+++ b/tests/test_matching_ambiguous.py
@@ -25,6 +25,17 @@ class TestAmbiguousMatch(unittest.TestCase):
         # "Etta Eyong" matches exactly one key -> still resolved
         self.assertEqual(match_name("Etta Eyong", "", index)["v"], 1)
 
+    def test_short_token_needs_a_whole_word(self):
+        index = index_by_name([{"nombre": "johnny cardoso", "v": 1}])
+        # "oso" is inside "cardOSO" but is not his name
+        self.assertIsNone(match_name("Oso", "", index))
+        self.assertEqual(match_name("Oso", "", index_by_name(
+            [{"nombre": "joaquin oso", "v": 2}]))["v"], 2)
+
+    def test_long_tokens_still_match_by_substring(self):
+        index = index_by_name([{"nombre": "orri steinn skarsson", "v": 1}])
+        self.assertEqual(match_name("Oskarsson", "", index)["v"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_matching_ambiguous.py
+++ b/tests/test_matching_ambiguous.py
@@ -26,15 +26,41 @@ class TestAmbiguousMatch(unittest.TestCase):
         self.assertEqual(match_name("Etta Eyong", "", index)["v"], 1)
 
     def test_short_token_needs_a_whole_word(self):
-        index = index_by_name([{"nombre": "johnny cardoso", "v": 1}])
-        # "oso" is inside "cardOSO" but is not his name
+        # "oso" is inside cardOSO and OSOrio but is neither man's name
+        index = index_by_name([{"nombre": "johnny cardoso", "v": 1},
+                               {"nombre": "abiel osorio", "v": 2}])
         self.assertIsNone(match_name("Oso", "", index))
         self.assertEqual(match_name("Oso", "", index_by_name(
-            [{"nombre": "joaquin oso", "v": 2}]))["v"], 2)
+            [{"nombre": "joaquin oso", "v": 3}]))["v"], 3)
 
-    def test_long_tokens_still_match_by_substring(self):
-        index = index_by_name([{"nombre": "orri steinn skarsson", "v": 1}])
-        self.assertEqual(match_name("Oskarsson", "", index)["v"], 1)
+    def test_abbreviations_are_prefixes(self):
+        index = index_by_name([{"nombre": "javier hernandez", "v": 1},
+                               {"nombre": "adria altimira", "v": 2},
+                               {"nombre": "adria pedrosa", "v": 3},
+                               {"nombre": "pedro bigas", "v": 4}])
+        self.assertEqual(match_name("Javi Hernández", "", index)["v"], 1)
+        self.assertEqual(match_name("A. Alti", "", index)["v"], 2)
+        # a surname is not an abbreviation of a shorter first name
+        self.assertEqual(match_name("Pedrosa", "", index)["v"], 3)
+        # "Pedro" is both a whole word and a prefix of pedrosa: ambiguous
+        self.assertIsNone(match_name("Pedro", "", index))
+
+    def test_initials_must_agree_with_the_key(self):
+        index = index_by_name([{"nombre": "david jimenez", "v": 1},
+                               {"nombre": "isra dominguez", "v": 2},
+                               {"nombre": "johnny cardoso", "v": 3},
+                               {"nombre": "alberto moleiro", "v": 4}])
+        self.assertEqual(match_name("D. Jiménez", "", index)["v"], 1)
+        self.assertIsNone(match_name("J. David", "", index))
+        self.assertIsNone(match_name("C. Dominguez", "", index))
+        self.assertEqual(match_name("John C.", "", index)["v"], 3)
+        self.assertIsNone(match_name("Alberto F.", "", index))
+
+    def test_initials_are_ignored_when_the_key_has_no_spare_word(self):
+        index = index_by_name([{"nombre": "terrats", "v": 1},
+                               {"nombre": "pathe ciss", "v": 2}])
+        self.assertEqual(match_name("R. Terrats", "", index)["v"], 1)
+        self.assertEqual(match_name("Pathé I. Ciss", "", index)["v"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_matching_ambiguous.py
+++ b/tests/test_matching_ambiguous.py
@@ -61,6 +61,17 @@ class TestAmbiguousMatch(unittest.TestCase):
                                {"nombre": "pathe ciss", "v": 2}])
         self.assertEqual(match_name("R. Terrats", "", index)["v"], 1)
         self.assertEqual(match_name("Pathé I. Ciss", "", index)["v"], 2)
+        # a two-word key still has to account for the initial
+        self.assertIsNone(match_name("J. David Jimenez", "",
+                                     index_by_name([{"nombre": "david jimenez"}])))
+
+    def test_several_initials_keep_their_order(self):
+        index = index_by_name([{"nombre": "carlos david smith", "v": 1},
+                               {"nombre": "smith david carlos", "v": 2}])
+        self.assertIsNone(match_name("D. C. Smith", "", index))
+        self.assertEqual(match_name("C. D. Smith", "", index)["v"], 1)
+        self.assertIsNone(match_name("Smith C. D.", "", index))
+        self.assertEqual(match_name("Smith D. C.", "", index)["v"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The token fallback checked `t in key`, so a short nickname matched any name containing it as a substring: "Oso" (Joaquín Oso, Sevilla) resolved to "johnny cardoso". Whole-word matching alone regressed the abbreviations the API actually uses (`Fer López`, `Javi Hernández`, `A. Alti`), as measured in the review below.

The rule now: a token equals a word or, from 4 chars, is a prefix of one; tokens are consumed in order; initials are evidence, not noise (a leading `C.` must agree with a word before the surname, a trailing one with a word after it; middle initials and single-word keys skip the check).

Measured over the 834 API players against the two production name indices, old vs new:

- `probable_lineups`: 12 lost (10 of them cross-club false positives such as `C. Alvarez` -> yeray alvarez), 17 gained, all same-club.
- `trends_index`: 5 lost (4 false positives), 29 gained, all same-club.

Real losses: `Fer Niño` (3-char prefix) and `A. Fortuño` in lineups, where futbolfantasy's slug drops the accented initial (`ngel-fortuno`).

Regression tests cover the substring case, prefix abbreviations, initials and the single-word key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved name matching for initials and abbreviated tokens.
  * Prevented short tokens from matching arbitrary portions of longer words.
  * Ensured leading and trailing initials align with the corresponding name words.
  * Preserved matching when no additional word remains for an initial to validate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->